### PR TITLE
Best practices, initial version

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -12,6 +12,7 @@
 
 # Developer Guides
 
+- [Best Practices](./best-practices.md)
 - [Developer Quickstart](./quickstart.md)
 - [Initiating a Deposit](./deposit.md)
 - [Initiating a Withdrawal](./withdrawal.md)

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -1,0 +1,1 @@
+# Best Practices

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -18,6 +18,96 @@ Please don't use direct I/O calls in libraries at all costs. You can bind direct
 
 Try to avoid using multithreading and async programming in a library. Use simple synchronous functions which transform a state. A top-level application may decide how to bind the functions together using different techniques, such as a [thread pool](https://en.wikipedia.org/wiki/Thread_pool).
 
+## Documentation
+
+Use MarkDown to document a project. The GitHub MarkDown supports [Mermaid diagram](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams) and [LaTeX math equations](https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/writing-mathematical-expressions).
+
+## Git Workflow
+
+Use `main` branch as a default branch. The branch should be used for active development. Please, don't create long-lived feature branches. You may create a long-living branch to create a fix for a critical bug in an old version of a package.
+
+Use only squashed merge in PRs to keep the history clean and linear. The PR branch should be deleted after the merge.
+
+Try to avoid merges between branches. Merge changes from `main` into your branch instead. Multiple small atomic PRs are preferred to a single large PR. This will help to avoid merge conflicts and make the review process easier.
+
+### Example
+
+Our current state is
+- `main` - active development
+- `v1.0` - bug fixes for version 1.0.
+- `v1.1` - bug fixes for version 1.1.
+- `v2.0` - bug fixes for version 2.0.
+
+```mermaid
+gitGraph
+  commit id: "v0.1.0"
+  commit id: "v1.0.0"
+  branch v1.0
+  checkout main
+  commit id: "v1.1.0-alpha"
+  checkout v1.0
+  commit id: "v1.0.1 (critical bug fix)"
+  checkout main
+  commit id: "v1.1"
+  branch v1.1
+  checkout main
+  commit id: "v2.0.0-alpha"
+  checkout v1.1
+  commit id: "v1.1.1 (critical bug fix)"
+  checkout v1.0
+  commit id: "v1.0.2 (critical bug fix)"
+  checkout main
+  commit id: "v2.0.0"
+```
+
+Then, we are working on `issue12` and `issue13`:
+```mermaid
+%%{init:{'themeVariables':{'git0':'#00f','git1':'#0f0','git2':'#0ff'}}}%%
+gitGraph
+  commit id: "issue9"
+  commit id: "issue10"
+  branch issue12
+  commit id: "AB34..."
+  checkout main
+  branch issue13
+  commit id: "56FE..."
+  commit id: "DDE0..."
+  checkout issue12
+  commit id: "82E4..."
+```
+
+Now, `issue13` PR is merged, and we are working on `issue14`:
+```mermaid
+%%{init:{'themeVariables':{'git0':'#00f','git1':'#0f0','git2':'#f0f'}}}%%
+gitGraph
+  commit id: "issue9"
+  commit id: "issue10"
+  branch issue12
+  commit id: "AB34..."
+  checkout main
+  commit id: "issue13"
+  branch issue14
+  commit id: "3480..."
+  checkout issue12
+  commit id: "82E4..."
+  merge main
+```
+      
+After that, `issue12` PR is merged, and we are working on `issue14`:
+```mermaid
+%%{init:{'themeVariables':{'git0':'#00f','git1':'#f0f'}}}%%
+gitGraph
+  commit id: "issue9"
+  commit id: "issue10"
+  commit id: "issue13"
+  branch issue14
+  commit id: "3480..."
+  checkout main
+  commit id: "issue12"
+  checkout issue14
+  merge main
+```
+
 ## Rust Conventions
 
 To use the convention over configuration principle in Rust, see [project layout](https://doc.rust-lang.org/cargo/guide/project-layout.html).
@@ -29,6 +119,12 @@ A library source code should avoid direct usage of I/O. An executable from `src/
 Always use workspace dependencies. This way, we can ensure we don't have [diamond dependency problem](https://en.wikipedia.org/wiki/Dependency_hell#Problems).
 
 Use `--release` for testing and deploying, `cargo build --release`, `cargo test --release`. We don't need to test binaries that we will not ship, such as `debug` binaries.
+
+### Rust Documentation:
+
+Every Rust package should have a README.md file. This README.md file is also used to generate a front page for a create when published on https://crates.io/. the README.md should contain instructions on how to build, test, and run the package and prerequisites if needed. 
+Rust comments supports examples. Please, provide comments with correct examples. Use cargo test --doc to run the examples as tests.
+use cargo doc --open to generate documentation and open it in a browser.
 
 ### Example Of A Rust Workspace With Multiple Packages
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -30,7 +30,7 @@ Always use workspace dependencies, this way we can make sure that we don't have 
 
 Use `--release` for testing and deployng, `cargo build --release`, `cargo test --release`. We don't need to test binaries which we will not ship, such as `debug` binaries.
 
-### Example Of Rust Project With Multiple Packages
+### Example Of A Rust Workspace With Multiple Packages
 
 ```
 - a\

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -28,7 +28,23 @@ A name of the package should match a name of the package directory.
 
 Always use workspace dependencies, this way we can make sure that we don't have [diamond dependency problem](https://en.wikipedia.org/wiki/Dependency_hell#Problems).
 
+Use `--release` for testing and deployng, `cargo build --release`, `cargo test --release`. We don't need to test binaries which we will not ship, such as `debug` binaries.
+
 ### Example Of Rust Project With Multiple Packages
+
+```
+- a\
+  - src\
+    - bin\
+      - a.rs
+    - lib.rs
+- b\
+  - src\
+    - bin\
+      - b.rs
+    - lib.rs
+- Cargo.toml
+```
 
 - `Cargo.toml`
   ```toml
@@ -54,3 +70,4 @@ Always use workspace dependencies, this way we can make sure that we don't have 
   a.path = "../a"
   serde.workspace = true
   ```
+

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -10,7 +10,7 @@ If you can do something without configuring, e.g., using default settings, pleas
 
 ### Design Patterns And Anti-Patterns
 
-Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, if you introduce anti-patterns, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern), it damages the quality of our software.
+Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, if you introduce anti-patterns, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern#Criticism), it damages the quality of our software.
 
 ### No Direct Usage Of I/O
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -10,12 +10,12 @@ If you can do something without configuring, e.g., using default settings, pleas
 
 ### Design Patterns And Anti-Patterns
 
-Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, introducing an anti-pattern, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern#Criticism), will damage our software's quality.
+Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, introducing an anti-pattern, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern#Criticism), will damage our software's quality. 
 
 ### No Direct Usage Of I/O
 
-Please don't use direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them. 
+Please don't use direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them.
 
 ## Rust Conventions
 
-To use the convention over configuration principle in Rust, see [https://doc.rust-lang.org/cargo/guide/project-layout.html](https://doc.rust-lang.org/cargo/guide/project-layout.html).
+To use the convention over configuration principle in Rust, see [project layout](https://doc.rust-lang.org/cargo/guide/project-layout.html).

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -124,7 +124,7 @@ Use `--release` for testing and deploying, `cargo build --release`, `cargo test 
 
 ### Rust Documentation
 
-Every Rust package should have a README.md file. This README.md file is also used to generate a front page for a create when published on https://crates.io/. The README.md should contain instructions on how to build, test, and run the package and prerequisites if needed. Rust supports examples in comments. Please provide comments with correct examples. Use `cargo test --doc` to run the examples as tests. Use `cargo doc --open` to generate documentation and open it in a browser.
+Every Rust package should have a README.md file. This README.md file is also used to generate a front page for a crate when published on https://crates.io/. The README.md should contain instructions on how to build, test, and run the package and prerequisites if needed. Rust supports examples in comments. Please provide comments with correct examples. Use `cargo test --doc` to run the examples as tests. Use `cargo doc --open` to generate documentation and open it in a browser.
 
 ### Example Of A Rust Workspace With Multiple Packages
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -14,7 +14,9 @@ Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_
 
 ### No Direct Usage Of I/O
 
-Please don't use direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them.
+Please avoid using direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them.
+
+A direct I/O call works like a virus. If a function `g` uses another function `f` that uses a direct I/O call, then `g` also uses a direct I/O call. We have a huge challenge writing a unit test for the `g` function. Solution: If we can't change the `f` function, we may consider a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
 
 Try to avoid using multithreading and async programming in a library. Use simple synchronous functions that transform a state. A top-level application may decide how to bind the functions using different techniques, such as a [thread pool](https://en.wikipedia.org/wiki/Thread_pool). 
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -2,7 +2,7 @@
 
 ## General Principles
 
-The main principle is simplification. Please keep it simple, and don't add new unnecessaries. In particular, see [Occam's razor](https://en.wikipedia.org/wiki/Occam%27s_razor#Software_development).
+The main principle is simplification. Please keep it simple and don't add something new unnecessarily. In particular, see [Occam's razor](https://en.wikipedia.org/wiki/Occam%27s_razor#Software_development).
 
 ### Convention Over Configuration
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -2,7 +2,7 @@
 
 ## General Principles
 
-The main principle is simplification. Please keep it simple, and don't add new unnecessaries. In particular, see [Occam's razor].
+The main principle is simplification. Please keep it simple, and don't add new unnecessaries. In particular, see [Occam's razor](https://en.wikipedia.org/wiki/Occam%27s_razor).
 
 ### Convention Over Configuration
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -14,7 +14,7 @@ Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_
 
 ### No Direct Usage Of I/O
 
-Please avoid using direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them.
+Please avoid using direct I/O calls in libraries at all costs - I/O can be bound directly in the final application. Our libraries should never use direct I/O in an ideal world, as I/O destroys [deterministic behavior](https://en.wikipedia.org/wiki/Deterministic_system). [Determinism](https://en.wikipedia.org/wiki/Determinism) is essential for testing and debugging because it allows us to reliably reproduce behavior. If we can avoid I/O in our libraries, we may achieve 100% test coverage for them.
 
 A direct I/O call works like a virus. If a function `g` uses another function `f` that uses a direct I/O call, then `g` also uses a direct I/O call. Now, we have a huge challenge writing a unit test for the `g` function. Solution: If we can't change the `f` function, we may consider using a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -1,1 +1,21 @@
 # Best Practices
+
+## General Principles
+
+The main principle is simplification. Please keep it simple, and don't add new unnecessaries. In particular, see [Occam's razor].
+
+### Convention Over Configuration
+
+If you can do something without configuring, e.g., using default settings, please do. Try to avoid introducing new "better" conventions. For more details, see [Convention over configuration](https://en.wikipedia.org/wiki/Convention_over_configuration). Using fewer configurations reduces information noise.
+
+### Design Patterns And Anti-Patterns
+
+Don't worry much about [Software design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method pattern](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, if you introduce anti-patterns, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern), it damages the quality of our software.
+
+### No Direct Usage Of I/O
+
+Please don't use direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them. 
+
+## Rust Conventions
+
+To use the convention over configuration principle in Rust, see [https://doc.rust-lang.org/cargo/guide/project-layout.html](https://doc.rust-lang.org/cargo/guide/project-layout.html).

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -16,6 +16,8 @@ Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_
 
 Please don't use direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them.
 
+Also, try to avoid using multithreading and async programming in a library, use simple synchronous functions which transform a state. A top level application may decide how to bind the functions together using different technique, such as a thread pool.
+
 ## Rust Conventions
 
 To use the convention over configuration principle in Rust, see [project layout](https://doc.rust-lang.org/cargo/guide/project-layout.html).

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -1,5 +1,7 @@
 # Best Practices
 
+This document is designed to provide guidance from common sense and experience. When you design a system, you should verify if the system follows this guidance. If not, you should have a good reason for that. There is always room for exceptions but we need to justify them. Feel free to challenge any principle of the document at any time.
+
 ## General Principles
 
 The main principle is simplification. Please keep it simple and don't add something new unnecessarily. In particular, see [Occam's razor](https://en.wikipedia.org/wiki/Occam%27s_razor#Software_development).
@@ -14,7 +16,7 @@ Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_
 
 ### No Direct Usage Of I/O
 
-Please avoid using direct I/O calls in libraries at all costs - I/O can be bound directly in the final application. Our libraries should never use direct I/O in an ideal world, as I/O destroys [deterministic behavior](https://en.wikipedia.org/wiki/Deterministic_system). [Determinism](https://en.wikipedia.org/wiki/Determinism) is essential for testing and debugging because it allows us to reliably reproduce behavior. If we can avoid I/O in our libraries, we may achieve 100% test coverage for them.
+Please avoid using direct I/O calls in libraries at all costs - I/O can be bound directly in the final application. Our libraries should never use direct I/O in an ideal world, as I/O destroys [deterministic behavior](https://en.wikipedia.org/wiki/Deterministic_system). [Determinism](https://en.wikipedia.org/wiki/Determinism) is essential for testing and debugging because it allows us to reproduce behavior reliably. If we can avoid I/O in our libraries, we may achieve 100% test coverage for them.
 
 A direct I/O call works like a virus. If a function `g` uses another function `f` that uses a direct I/O call, then `g` also uses a direct I/O call. Now, we have a huge challenge writing a unit test for the `g` function. Solution: If we can't change the `f` function, we may consider using a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -16,7 +16,7 @@ Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_
 
 Please avoid using direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them.
 
-A direct I/O call works like a virus. If a function `g` uses another function `f` that uses a direct I/O call, then `g` also uses a direct I/O call. Now, we have a huge challenge writing a unit test for the `g` function. Solution: If we can't change the `f` function, we may consider a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
+A direct I/O call works like a virus. If a function `g` uses another function `f` that uses a direct I/O call, then `g` also uses a direct I/O call. Now, we have a huge challenge writing a unit test for the `g` function. Solution: If we can't change the `f` function, we may consider using a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
 
 Try to avoid using multithreading and async programming in a library. Use simple synchronous functions that transform a state. A top-level application may decide how to bind the functions using different techniques, such as a [thread pool](https://en.wikipedia.org/wiki/Thread_pool). 
 
@@ -118,7 +118,9 @@ To use the convention over configuration principle in Rust, see [project layout]
 
 Don't create an executable package. Always create a library package `cargo new --lib {library-name}`. If you need an executable, use an existing library and create an executable in `{library-name}/src/bin`. 
 
-A library source code should avoid direct usage of I/O. An executable from `src/bin` should only bind I/O to a library, and all other logic should be in a library. A library name should match a directory name.
+A library source code should avoid direct usage of I/O. An executable from `src/bin` should only bind I/O to a library, and all other logic should be in a library. 
+
+A library name should match a directory name. Make sure that the name of the package is not reserved on https://crates.io/. Publish an empty version of the package to https://crates.io/ to reserve the name. Otherwise, you may need to rename the package later.
 
 Always use workspace dependencies. This way, we can ensure we don't have [diamond dependency problem](https://en.wikipedia.org/wiki/Dependency_hell#Problems).
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -16,7 +16,7 @@ Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_
 
 Please don't use direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them.
 
-Try to avoid using multithreading and async programming in a library. Use simple synchronous functions which transform a state. A top-level application may decide how to bind the functions together using different techniques, such as a [thread pool](https://en.wikipedia.org/wiki/Thread_pool).
+Try to avoid using multithreading and async programming in a library. Use simple synchronous functions that transform a state. A top-level application may decide how to bind the functions using different techniques, such as a [thread pool](https://en.wikipedia.org/wiki/Thread_pool). 
 
 ## Documentation
 
@@ -24,7 +24,7 @@ Use MarkDown to document a project. The GitHub MarkDown supports [Mermaid diagra
 
 ## Git Workflow
 
-Use `main` branch as a default branch. The branch should be used for active development. Please, don't create long-lived feature branches. You may create a long-living branch to create a fix for a critical bug in an old version of a package.
+Use `main` branch as a default branch. The branch should be used for active development. Please don't create long-lived feature branches. You may create a long-living branch to create a fix for a critical bug in an old version of a package.
 
 For example:
 - `main` - active development
@@ -120,7 +120,7 @@ A library source code should avoid direct usage of I/O. An executable from `src/
 
 Always use workspace dependencies. This way, we can ensure we don't have [diamond dependency problem](https://en.wikipedia.org/wiki/Dependency_hell#Problems).
 
-Use `--release` for testing and deploying, `cargo build --release`, `cargo test --release`. We don't need to test binaries that we will not ship, such as `debug` binaries.
+Use `--release` for testing and deploying, `cargo build --release`, `cargo test --release`. We don't need to test binaries we will not ship, such as `debug` binaries.
 
 ### Rust Documentation
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -6,7 +6,7 @@ The main principle is simplification. Please keep it simple, and don't add new u
 
 ### Convention Over Configuration
 
-If you can do something without configuring, e.g., using default settings, please do. Try to avoid introducing new "better" conventions. For more details, see [Convention over configuration](https://en.wikipedia.org/wiki/Convention_over_configuration). Using fewer configurations reduces information noise.
+If you can do something without configuring, e.g., using default settings, please do. Try to avoid introducing new "better" conventions. For more details, see [convention over configuration](https://en.wikipedia.org/wiki/Convention_over_configuration). Using fewer configurations reduces information noise.
 
 ### Design Patterns And Anti-Patterns
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -10,7 +10,7 @@ If you can do something without configuring, e.g., using default settings, pleas
 
 ### Design Patterns And Anti-Patterns
 
-Don't worry much about [Software design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method pattern](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, if you introduce anti-patterns, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern), it damages the quality of our software.
+Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method pattern](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, if you introduce anti-patterns, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern), it damages the quality of our software.
 
 ### No Direct Usage Of I/O
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -120,11 +120,9 @@ Always use workspace dependencies. This way, we can ensure we don't have [diamon
 
 Use `--release` for testing and deploying, `cargo build --release`, `cargo test --release`. We don't need to test binaries that we will not ship, such as `debug` binaries.
 
-### Rust Documentation:
+### Rust Documentation
 
-Every Rust package should have a README.md file. This README.md file is also used to generate a front page for a create when published on https://crates.io/. the README.md should contain instructions on how to build, test, and run the package and prerequisites if needed. 
-Rust comments supports examples. Please, provide comments with correct examples. Use cargo test --doc to run the examples as tests.
-use cargo doc --open to generate documentation and open it in a browser.
+Every Rust package should have a README.md file. This README.md file is also used to generate a front page for a create when published on https://crates.io/. The README.md should contain instructions on how to build, test, and run the package and prerequisites if needed. Rust supports examples in comments. Please provide comments with correct examples. Use `cargo test --doc` to run the examples as tests. Use `cargo doc --open` to generate documentation and open it in a browser.
 
 ### Example Of A Rust Workspace With Multiple Packages
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -19,3 +19,38 @@ Please don't use direct I/O calls in libraries at all costs. You can bind direct
 ## Rust Conventions
 
 To use the convention over configuration principle in Rust, see [project layout](https://doc.rust-lang.org/cargo/guide/project-layout.html).
+
+Don't create an executable package, always create a library package `cargo new --lib {library-name}`. If you need an executable, either use an existing library and create an executable in `{library-name}/src/bin`. 
+
+A library source code should avoid direct usage of I/O. An executable from `src/bin` should only bind I/O to a library and all other logic should be in a library.
+
+A name of the package should match a name of the package directory.
+
+Always use workspace dependencies, this way we can make sure that we don't have [diamond dependency problem](https://en.wikipedia.org/wiki/Dependency_hell#Problems).
+
+### Example Of Rust Project With Multiple Packages
+
+- `Cargo.toml`
+  ```toml
+  [workspace]
+  members = ["a", "b"]
+  [workspace.dependencies]
+  serde = "1.0"
+  ```
+- `a\Cargo.toml`
+  ```toml
+  [package]
+  name = "a"
+  # ...
+  [dependencies]
+  serde.workspace = true
+  ```
+- `b\Cargo.toml`
+  ```toml
+  [package]
+  name = "b"
+  # ...
+  [dependencies]
+  a.path = "../a"
+  serde.workspace = true
+  ```

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -16,7 +16,7 @@ Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_
 
 Please avoid using direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them.
 
-A direct I/O call works like a virus. If a function `g` uses another function `f` that uses a direct I/O call, then `g` also uses a direct I/O call. We have a huge challenge writing a unit test for the `g` function. Solution: If we can't change the `f` function, we may consider a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
+A direct I/O call works like a virus. If a function `g` uses another function `f` that uses a direct I/O call, then `g` also uses a direct I/O call. Now, we have a huge challenge writing a unit test for the `g` function. Solution: If we can't change the `f` function, we may consider a [dependency injection](https://en.wikipedia.org/wiki/Dependency_injection).
 
 Try to avoid using multithreading and async programming in a library. Use simple synchronous functions that transform a state. A top-level application may decide how to bind the functions using different techniques, such as a [thread pool](https://en.wikipedia.org/wiki/Thread_pool). 
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -16,21 +16,19 @@ Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_
 
 Please don't use direct I/O calls in libraries at all costs. You can bind direct I/O in the final application. Our libraries should never use direct I/O in the ideal world. I/O destroys deterministic behavior. Determinism is essential for testing and debugging because it allows us to reproduce behavior. If we can avoid I/O in our libraries, we can achieve 100% test coverage for them.
 
-Also, try to avoid using multithreading and async programming in a library, use simple synchronous functions which transform a state. A top level application may decide how to bind the functions together using different technique, such as a thread pool.
+Try to avoid using multithreading and async programming in a library. Use simple synchronous functions which transform a state. A top-level application may decide how to bind the functions together using different techniques, such as a [thread pool](https://en.wikipedia.org/wiki/Thread_pool).
 
 ## Rust Conventions
 
 To use the convention over configuration principle in Rust, see [project layout](https://doc.rust-lang.org/cargo/guide/project-layout.html).
 
-Don't create an executable package, always create a library package `cargo new --lib {library-name}`. If you need an executable, either use an existing library and create an executable in `{library-name}/src/bin`. 
+Don't create an executable package. Always create a library package `cargo new --lib {library-name}`. If you need an executable, use an existing library and create an executable in `{library-name}/src/bin`. 
 
-A library source code should avoid direct usage of I/O. An executable from `src/bin` should only bind I/O to a library and all other logic should be in a library.
+A library source code should avoid direct usage of I/O. An executable from `src/bin` should only bind I/O to a library, and all other logic should be in a library. A library name should match a directory name.
 
-A name of the package should match a name of the package directory.
+Always use workspace dependencies. This way, we can ensure we don't have [diamond dependency problem](https://en.wikipedia.org/wiki/Dependency_hell#Problems).
 
-Always use workspace dependencies, this way we can make sure that we don't have [diamond dependency problem](https://en.wikipedia.org/wiki/Dependency_hell#Problems).
-
-Use `--release` for testing and deployng, `cargo build --release`, `cargo test --release`. We don't need to test binaries which we will not ship, such as `debug` binaries.
+Use `--release` for testing and deploying, `cargo build --release`, `cargo test --release`. We don't need to test binaries that we will not ship, such as `debug` binaries.
 
 ### Example Of A Rust Workspace With Multiple Packages
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -10,7 +10,7 @@ If you can do something without configuring, e.g., using default settings, pleas
 
 ### Design Patterns And Anti-Patterns
 
-Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method pattern](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, if you introduce anti-patterns, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern), it damages the quality of our software.
+Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, if you introduce anti-patterns, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern), it damages the quality of our software.
 
 ### No Direct Usage Of I/O
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -10,7 +10,7 @@ If you can do something without configuring, e.g., using default settings, pleas
 
 ### Design Patterns And Anti-Patterns
 
-Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, if you introduce anti-patterns, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern#Criticism), it damages the quality of our software.
+Don't worry much about [design patterns](https://en.wikipedia.org/wiki/Software_design_pattern), but avoid [anti-patterns](https://en.wikipedia.org/wiki/Anti-pattern). If you don't use some well-known design patterns, like the [factory method](https://en.wikipedia.org/wiki/Factory_method_pattern), it's okay. However, introducing an anti-pattern, such as a [mutable singleton](https://en.wikipedia.org/wiki/Singleton_pattern#Criticism), will damage our software's quality.
 
 ### No Direct Usage Of I/O
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -138,12 +138,17 @@ Every Rust package should have a README.md file. This README.md file is also use
     - bin\
       - a.rs
     - lib.rs
+  - Cargo.toml
+  - README.md
 - b\
   - src\
     - bin\
       - b.rs
     - lib.rs
+  - Cargo.toml
+  - README.md
 - Cargo.toml
+- README.md
 ```
 
 - `Cargo.toml`

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -2,7 +2,7 @@
 
 ## General Principles
 
-The main principle is simplification. Please keep it simple, and don't add new unnecessaries. In particular, see [Occam's razor](https://en.wikipedia.org/wiki/Occam%27s_razor).
+The main principle is simplification. Please keep it simple, and don't add new unnecessaries. In particular, see [Occam's razor](https://en.wikipedia.org/wiki/Occam%27s_razor#Software_development).
 
 ### Convention Over Configuration
 

--- a/src/best-practices.md
+++ b/src/best-practices.md
@@ -26,13 +26,7 @@ Use MarkDown to document a project. The GitHub MarkDown supports [Mermaid diagra
 
 Use `main` branch as a default branch. The branch should be used for active development. Please, don't create long-lived feature branches. You may create a long-living branch to create a fix for a critical bug in an old version of a package.
 
-Use only squashed merge in PRs to keep the history clean and linear. The PR branch should be deleted after the merge.
-
-Try to avoid merges between branches. Merge changes from `main` into your branch instead. Multiple small atomic PRs are preferred to a single large PR. This will help to avoid merge conflicts and make the review process easier.
-
-### Example
-
-Our current state is
+For example:
 - `main` - active development
 - `v1.0` - bug fixes for version 1.0.
 - `v1.1` - bug fixes for version 1.1.
@@ -60,7 +54,15 @@ gitGraph
   commit id: "v2.0.0"
 ```
 
-Then, we are working on `issue12` and `issue13`:
+### Linear History And Squashed Commits
+
+Use only squashed merge in PRs to keep the history clean and linear. The PR branch should be deleted after the merge.
+
+Try to avoid merges between branches. Merge changes from `main` into your branch instead. Multiple small atomic PRs are preferred to a single large PR. This will help to avoid merge conflicts and make the review process easier.
+
+For Example:
+
+We are working on `issue12` and `issue13`:
 ```mermaid
 %%{init:{'themeVariables':{'git0':'#00f','git1':'#0f0','git2':'#0ff'}}}%%
 gitGraph
@@ -76,7 +78,7 @@ gitGraph
   commit id: "82E4..."
 ```
 
-Now, `issue13` PR is merged, and we are working on `issue14`:
+Then, `issue13` PR is merged, and we are working on `issue14`:
 ```mermaid
 %%{init:{'themeVariables':{'git0':'#00f','git1':'#0f0','git2':'#f0f'}}}%%
 gitGraph


### PR DESCRIPTION
This is an initial version. I plan to add more best practices, especially related to coding. 

Should we split the document into multiple, such as "generic", "Rust", "Git"? If yes, I can do it in the next PR.

Here's a [preview of the document](https://github.com/stacks-network/sbtc-docs/blob/sergey-best-practices/src/best-practices.md).