### PR TITLE
Nakamoto signer docs Updates

### DIFF
--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -8,7 +8,7 @@
 - [How to Participate as a Stacker](./how-to-stacker.md)
 - [How to Operate a Signer](./how-to-signer.md)
   - [Developer Release](./developer-release-signer.md)
-  - [Nakamoto]()
+  - [Nakamoto Release]()
     - [Nakamoto Signer Get Started](./nakamoto-signer-developer-guide.md)
 - [Applications on sBTC](./applications.md)
 

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -7,7 +7,9 @@
 - [How to Deposit and Withdraw](./how-to-deposit-and-withdraw.md)
 - [How to Participate as a Stacker](./how-to-stacker.md)
 - [How to Operate a Signer](./how-to-signer.md)
-  - [Signer Configuration](./how-to-signer-config.md)
+  - [Developer Release](./developer-release-signer.md)
+  - [Nakamoto]()
+    - [Nakamoto Signer Get Started](./nakamoto-signer-developer-guide.md)
 - [Applications on sBTC](./applications.md)
 
 # Developer Guides
@@ -31,6 +33,7 @@
   - [StackerDB](./stacker-db.md)
 
 # sBTC Project
+
 - [sBTC Releases](./sbtc-releases.md)
   - [sBTC 0.1](./sbtc-releases/sbtc-dev.md)
     - [Reference implementation plan](./sbtc-releases/sbtc-dev/sbtc-dev-reference.md)

--- a/src/developer-release-signer.md
+++ b/src/developer-release-signer.md
@@ -1,0 +1,5 @@
+# Developer Release
+
+[The sBTC Developer Release](./sbtc-releases/sbtc-dev.md) is a minimum-viable testnet deployment of sBTC and was decided to be released without the without the complexity of adding a decentralized set of signers to validate sBTC deposits/withdrawals.
+
+Therefore our beloved the Developer Release aka Version 0.1 Alpha Romeo won't have signer when deployed to public test net.

--- a/src/developer-release-signer.md
+++ b/src/developer-release-signer.md
@@ -1,5 +1,5 @@
 # Developer Release
 
-[The sBTC Developer Release](./sbtc-releases/sbtc-dev.md) is a minimum-viable testnet deployment of sBTC and was decided to be released without the without the complexity of adding a decentralized set of signers to validate sBTC deposits/withdrawals.
+[The sBTC Developer Release](./sbtc-releases/sbtc-dev.md) is a minimum-viable testnet deployment of sBTC and was decided to be released without the complexity of adding a decentralized set of signers to validate sBTC deposits/withdrawals.
 
-Therefore our beloved the Developer Release aka Version 0.1 Alpha Romeo won't have signer when deployed to public test net.
+Therefore our beloved Developer Release aka Version 0.1 Alpha Romeo won't have signer when deployed to public test net.

--- a/src/developer-release-signer.md
+++ b/src/developer-release-signer.md
@@ -2,4 +2,4 @@
 
 [The sBTC Developer Release](./sbtc-releases/sbtc-dev.md) is a minimum-viable testnet deployment of sBTC and was decided to be released without the complexity of adding a decentralized set of signers to validate sBTC deposits/withdrawals.
 
-Therefore our beloved Developer Release aka Version 0.1 Alpha Romeo won't have signer when deployed to public test net.
+Therefore our beloved Developer Release aka Version 0.1 Alpha Romeo only has one single signer that is operated by a central authority.

--- a/src/how-to-signer.md
+++ b/src/how-to-signer.md
@@ -1,53 +1,67 @@
 # How to operate a signer
-As a Stacker, you are responsible for ensuring the accuracy and integrity of incoming sBTC transactions. To satisfy this requirement and continue to earn BTC rewards, you must operate your own Signer or delegate your signing power to a third-party Signer. Below is a step-by-step guide to setting up and operating a Signer either by using the [default Signer implementation](#setting-up-a-default-signer) or by [utilizing the Signer SDK](#custom-signer-implementation).
 
-## Prerequisites
-Rust. To install, please [follow these instructions](https://www.rust-lang.org/tools/install).  
+As a Stacker, you are responsible for ensuring the accuracy and integrity of incoming sBTC transactions. To satisfy this requirement and continue to earn BTC rewards, you must operate your own Signer or delegate your signing power to a third-party Signer. Below is a step-by-step guide to setting up and operating a Signer either by using the [default Signer implementation](./nakamoto-signer-developer-guide.md) or by [utilizing the Signer SDK](./nakamoto-signer-developer-guide.md#custom-signer-implementation).
+
+<!-- ## Prerequisites
+
+Rust. To install, please [follow these instructions](https://www.rust-lang.org/tools/install).
 Git
 
 ## Setting up a Default Signer
 
 ### Building from Source
-If you wish to compile the default binary from source, follow the steps outlined below. Otherwise, [download the binary directly](#downloading-the-binary).  
 
-1. First, clone the Stacks sBTC mono repository:  
+If you wish to compile the default binary from source, follow the steps outlined below. Otherwise, [download the binary directly](#downloading-the-binary).
+
+1. First, clone the Stacks sBTC mono repository:
+
 ```console
 git clone https://github.com/Trust-Machines/stacks-sbtc.git
 ```
-2. Next, navigate to the stacks-signer-mini directory:  
+
+2. Next, navigate to the stacks-signer-mini directory:
+
 ```console
 cd stacks-sbtc/stacks-signer-mini
 ```
+
 3. Checkout the appropriate release branch you wish to use if you are not using the default main branch
+
 ```console
 git checkout main
 ```
-4. Compile the signer binary:  
-Note the binary path defaults to `target/release/stacks-signer-mini`.
+
+4. Compile the signer binary:
+   Note the binary path defaults to `target/release/stacks-signer-mini`.
+
 ```console
 cargo build --release
 ```
 
 ### Downloading the Binary
+
 1. First, download the precompiled default [signer binary](LINK).
 
 2. Untar the file
+
 ```console
 tar -xvf signer_binary.tar
 ```
-3.  Check Extracted Files:
-After running the untar command, the contents of the tar file should be extracted to the current directory. You should see the signer binary (stacks-signer-mini) and the configuration file (signer.toml) listed among the extracted files.
 
-2. Next, install the signer.
+3.  Check Extracted Files:
+    After running the untar command, the contents of the tar file should be extracted to the current directory. You should see the signer binary (stacks-signer-mini) and the configuration file (signer.toml) listed among the extracted files.
+
+4.  Next, install the signer.
+
 ```console
 cargo install --path stacks-signer-mini
 ```
 
 ### Configuring and Running the Binary
 
-1. Generate a key pair:  
-Create a cryptographic key pair (public key and private key) to uniquely identify yourself as a Signer.
-Safeguard your private key securely to prevent unauthorized access. There are multiple ways to generate a key pair, but consider using the [Stacks CLI](https://docs.hiro.so/get-started/command-line-interface):
+1. Generate a key pair:
+   Create a cryptographic key pair (public key and private key) to uniquely identify yourself as a Signer.
+   Safeguard your private key securely to prevent unauthorized access. There are multiple ways to generate a key pair, but consider using the [Stacks CLI](https://docs.hiro.so/get-started/command-line-interface):
 
 ```console
 # install CLI globally
@@ -59,21 +73,23 @@ stx make_keychain -t > cli_keychain.json
 ```
 
 2. Update the default config:
-Insert your private key into the conf/signer.toml file and update any mandatory options appropriately. Be sure to update any defaults configurations you like for auto signing transactions. For a breakdown of each configuration option, see [Signer Configuration](./how-to-signer-config.md).
+   Insert your private key into the conf/signer.toml file and update any mandatory options appropriately. Be sure to update any defaults configurations you like for auto signing transactions. For a breakdown of each configuration option, see [Signer Configuration](./how-to-signer-config.md).
 
-3. Run the binary:  
+3. Run the binary:
+
 ```console
 stacks-signer-mini --config conf/signer.toml
 ```
-4. Monitor Incoming Transactions:  
-The signer binary operates a web server/client and it can be navigated to by default at http://localhost:3000/. 
-Here you can see pending transactions and manually review and sign transactions that cannot be automatically signed on your behalf. Note that manual review is triggered based on the options you have set in your configuration file.
+
+4. Monitor Incoming Transactions:
+   The signer binary operates a web server/client and it can be navigated to by default at http://localhost:3000/.
+   Here you can see pending transactions and manually review and sign transactions that cannot be automatically signed on your behalf. Note that manual review is triggered based on the options you have set in your configuration file.
 
 ## Custom Signer Implementation
 
 If you wish to have more fine-grained control of the Signer binary and its transaction signing logic, you may wish to take advantage of the [Signer SDK](TODO: LINK TO GITHUB REPO).
 
-1. Set Up a New Rust Project  
+1. Set Up a New Rust Project
 
 To add a Signer library to your Rust project and create a main function that utilizes it, follow these step-by-step instructions:
 
@@ -86,9 +102,9 @@ cd my_signer
 
 Replace `my_signer` with your desired project name.
 
-2. Add Signer Library to the `Cargo.toml` File  
+2. Add Signer Library to the `Cargo.toml` File
 
-Open the `Cargo.toml` file in your project directory and add the Signer library as a dependency under the `[dependencies]` section. 
+Open the `Cargo.toml` file in your project directory and add the Signer library as a dependency under the `[dependencies]` section.
 
 ```toml
 [dependencies]
@@ -97,7 +113,7 @@ signer = "1.0.0"
 
 Specify the appropriate version that you wish to use. Make sure to check the latest version available on crates.io.
 
-3. Import the Signer Library in Your Rust Code  
+3. Import the Signer Library in Your Rust Code
 
 In your `main.rs` file (located in the `src` folder by default), import the Signer library at the beginning of the file:
 
@@ -131,11 +147,11 @@ fn main() {
 }
 ```
 
-5. Build and Run Your Signer  
+5. Build and Run Your Signer
 
 Now that you've added the Signer library and created the main function, you can build and run your custom signer using Cargo:
 
 ```bash
 cargo build
 cargo run
-```
+``` -->

--- a/src/how-to-signer.md
+++ b/src/how-to-signer.md
@@ -1,6 +1,6 @@
 # How to operate a signer
 
-As a Stacker, you are responsible for ensuring the accuracy and integrity of incoming sBTC transactions. To satisfy this requirement and continue to earn BTC rewards, you must operate your own Signer or delegate your signing power to a third-party Signer. Below is a step-by-step guide to setting up and operating a Signer either by using the [default Signer implementation](./nakamoto-signer-developer-guide.md) or by [utilizing the Signer SDK](./nakamoto-signer-developer-guide.md#custom-signer-implementation).
+As a Stacker, you are responsible for ensuring the accuracy and integrity of incoming sBTC transactions. To satisfy this requirement and continue to earn BTC rewards, you must operate your own Signer or delegate your signing power to a third-party Signer. See the step-by-step guide to setting up and operating a Signer either by using the [default Signer implementation](./nakamoto-signer-developer-guide.md) or by [utilizing the Signer SDK](./nakamoto-signer-developer-guide.md#custom-signer-implementation).
 
 <!-- ## Prerequisites
 

--- a/src/nakamoto-signer-developer-guide.md
+++ b/src/nakamoto-signer-developer-guide.md
@@ -123,3 +123,74 @@ stacks-signer-mini --config conf/signer.toml
 ## Monitor Transactions
 
 The signer binary operates a web server/client and it can be navigated to by default at http://localhost:3000/ (unless otherwise specified from config). Here you can see pending transactions and manually review and sign transactions that cannot be automatically signed on your behalf. Note that manual review is triggered based on the options you have set in your configuration file.
+
+## Custom Signer Implementation
+
+If you wish to have more fine-grained control of the Signer binary and its transaction signing logic, you may wish to take advantage of the [Signer SDK](TODO: LINK TO GITHUB REPO).
+
+1. Set Up a New Rust Project
+
+To add a Signer library to your Rust project and create a main function that utilizes it, follow these step-by-step instructions:
+
+If you don't have an existing Rust project, create one using Cargo, Rust's package manager and build tool:
+
+```bash
+cargo new my_signer
+cd my_signer
+```
+
+Replace `my_signer` with your desired project name.
+
+2. Add Signer Library to the `Cargo.toml` File
+
+Open the `Cargo.toml` file in your project directory and add the Signer library as a dependency under the `[dependencies]` section.
+
+```toml
+[dependencies]
+signer = "1.0.0"
+```
+
+Specify the appropriate version that you wish to use. Make sure to check the latest version available on crates.io.
+
+3. Import the Signer Library in Your Rust Code
+
+In your `main.rs` file (located in the `src` folder by default), import the Signer library at the beginning of the file:
+
+```rust
+use signer::Signer;
+```
+
+4. Create a Main Function
+
+Add the main function to your `main.rs` file. This is where you'll utilize the Signer library to perform the required actions:
+
+```rust
+fn main() {
+    // Initialize the signer with a private key
+    let signer = Signer::new("your_private_key"); // Replace with the actual private key
+    // Must serve web client to utilize manual review
+    let _ = signer.serve_http("0.0.0.0", 3000);
+    while let Ok(transaction) = signer.retrieve_pending_transaction() {
+        // Trigger manual review for a specific address
+        if transaction.recipient.to_string() == "mr1iPkD9N3RJZZxXRk7xF9d36gffa6exNC" {
+            // Manually approve or deny a transaction
+            let _ = signer.trigger_manual_review(transaction);
+        } else if transaction.amount > 3418260000 {
+            // deny transactions with an amount greater than 1 million USD
+            let _ = signer.deny(transaction);
+        } else {
+            // Approve anything else
+            let _ = signer.approve(transaction);
+        }
+    }
+}
+```
+
+5. Build and Run Your Signer
+
+Now that you've added the Signer library and created the main function, you can build and run your custom signer using Cargo:
+
+```bash
+cargo build
+cargo run
+```

--- a/src/nakamoto-signer-developer-guide.md
+++ b/src/nakamoto-signer-developer-guide.md
@@ -16,7 +16,7 @@ Accessible Stacks node - A Stacks node running the stackerDB instance which is u
 
 Accessible Bitcoin node - A Bitcoin node used for transaction monitoring and broadcasting.
 
-A Stacks Address - Identify your address as a Signer
+A Stacks Private Key - Identify your address as a Signer
 
 ## Installing
 
@@ -39,7 +39,7 @@ cd stacks-blockchain/stacks-signer
 3. Checkout the appropriate release branch you wish to use if you are not using the default main branch
 
 ```console
-git checkout main
+git checkout master
 ```
 
 4. Compile the signer binary:  
@@ -60,7 +60,7 @@ tar -xvf signer_binary.tar
 ```
 
 3.  Check Extracted Files:
-    After running the untar command, the contents of the tar file should be extracted to the current directory. You should see the signer binary (stacks-signer-mini) and the configuration file (signer.toml) listed among the extracted files.
+    After running the untar command, the contents of the tar file should be extracted to the current directory. You should see the signer binary (stacks-signer) and the configuration file (signer.toml) listed among the extracted files.
 
 4.  Next, install the signer.
 
@@ -77,7 +77,8 @@ The signer takes a TOML config file with the following expected properties
 | `signer_private_key`        | `true`   | Stacks private key of the signer, used for signing sBTC transactions.                                                                                        |
 | `stacks_node_rpc_url`       | `true`   | Stacks node RPC URL that points to a node running the stackerDB instance which is used for signer communication and transaction monitoring and broadcasting. |
 | `bitcoin_node_rpc_url`      | `true`   | Bitcoin node RPC URL used for transaction monitoring and broadcasting.                                                                                       |
-| `revealer_rpc_url`          | `true`   | Revealer RRC URL                                                                                                                                             |
+| `stackerdb_event_endpoint`  | `true`   | RPC endpoint for receiving events from [StackerDB](https://github.com/stacks-network/stacks-blockchain/blob/develop/stackslib/src/net/stackerdb/mod.rs)      |
+| `stackerdb_contract_id`     | `false`  | StackerDB qualified contract ID for Signer communication. Defaults to "ST11Z60137Y96MF89K1KKRTA3CR6B25WY1Y931668.signers-stackerdb".                         |
 | `network`                   | `false`  | One of `['Signet', 'Regtest', 'Testnet', 'Bitcoin']`. Defaults to `Testnet`                                                                                  |
 | `signer_api_server_url`     | `false`  | Url at which to host the signer api server for transaction monitoring. Defaults to "http://localhost:3000".                                                  |
 | `auto_deny_block`           | `false`  | Number of blocks before signing deadline to auto deny a transaction waiting for manual review. Defaults to 10.                                               |
@@ -117,7 +118,7 @@ auto_deny_deadline_blocks = 120
 After installing and creating a config file to run the binary
 
 ```console
-stacks-signer-mini --config conf/signer.toml
+stacks-signer --config conf/signer.toml
 ```
 
 ## Monitor Transactions

--- a/src/nakamoto-signer-developer-guide.md
+++ b/src/nakamoto-signer-developer-guide.md
@@ -4,6 +4,10 @@ Draft documentation for sBTC Signer specifically for the Nakamoto [release](http
 
 The readers of this are assumed to be anyone who is looking to run a sBTC Signer with minimal custom configuration.
 
+# Disclaimer
+
+Development is on going and changes to the Signer configuration should be expected. This document will be updated every sprint to ensure its accuracy.
+
 ## Prerequisites
 
 Rust - [To install](https://www.rust-lang.org/tools/install).

--- a/src/nakamoto-signer-developer-guide.md
+++ b/src/nakamoto-signer-developer-guide.md
@@ -1,0 +1,121 @@
+# What is this
+
+Draft documentation for sBTC Signer specifically for the Nakamoto [release](https://stacks-network.github.io/sbtc-docs/sbtc-roadmap.html)
+
+The readers of this are assumed to be anyone who is looking to run a sBTC Signer with minimal custom configuration.
+
+## Prerequisites
+
+Rust - [To install](https://www.rust-lang.org/tools/install).
+
+Accessible Stacks node - A Stacks node running the stackerDB instance which is used for signer communication and transaction monitoring and broadcasting.
+
+Accessible Bitcoin node - A Bitcoin node used for transaction monitoring and broadcasting.
+
+A Stacks Address - Identify your address as a Signer
+
+## Installing
+
+### Building from Source
+
+If you wish to compile the default binary from source, follow the steps outlined below. Otherwise, download the binary directly (below)
+
+1. First, clone the Stacks sBTC mono repository:
+
+```console
+git clone git@github.com:stacks-network/stacks-blockchain.git
+```
+
+2. Next, navigate to the stacks-signer directory:
+
+```console
+cd stacks-blockchain/stacks-signer
+```
+
+3. Checkout the appropriate release branch you wish to use if you are not using the default main branch
+
+```console
+git checkout main
+```
+
+4. Compile the signer binary:  
+   Note the binary path defaults to `target/release/stacks-signer`.
+
+```console
+cargo build --release
+```
+
+### Downloading the Binary
+
+1. First, download the precompiled default [TODO:NEED:LINK](LINK).
+
+2. Untar the file
+
+```console
+tar -xvf signer_binary.tar
+```
+
+3.  Check Extracted Files:
+    After running the untar command, the contents of the tar file should be extracted to the current directory. You should see the signer binary (stacks-signer-mini) and the configuration file (signer.toml) listed among the extracted files.
+
+4.  Next, install the signer.
+
+```console
+cargo install --path stacks-signer
+```
+
+## Configuration
+
+The signer takes a TOML config file with the following expected properties
+
+| Key                         | Required | Description                                                                                                                                                  |
+| --------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `signer_private_key`        | `true`   | Stacks private key of the signer, used for signing sBTC transactions.                                                                                        |
+| `stacks_node_rpc_url`       | `true`   | Stacks node RPC URL that points to a node running the stackerDB instance which is used for signer communication and transaction monitoring and broadcasting. |
+| `bitcoin_node_rpc_url`      | `true`   | Bitcoin node RPC URL used for transaction monitoring and broadcasting.                                                                                       |
+| `revealer_rpc_url`          | `true`   | Revealer RRC URL                                                                                                                                             |
+| `network`                   | `false`  | One of `['Signet', 'Regtest', 'Testnet', 'Bitcoin']`. Defaults to `Testnet`                                                                                  |
+| `signer_api_server_url`     | `false`  | Url at which to host the signer api server for transaction monitoring. Defaults to "http://localhost:3000".                                                  |
+| `auto_deny_block`           | `false`  | Number of blocks before signing deadline to auto deny a transaction waiting for manual review. Defaults to 10.                                               |
+| `auto_approve_max_amount`   | `false`  | Maximum amount of a transactions that will be auto approved                                                                                                  |
+| `auto_deny_addresses_btc`   | `false`  | List of bitcoin addresses that trigger an auto deny                                                                                                          |
+| `auto_deny_addresses_stx`   | `false`  | List of stx addresses that trigger an auto deny                                                                                                              |
+| `auto_deny_deadline_blocks` | `false`  | The number of blocks before deadline at which point the transaction will be auto denied. Default is 10 blocks.                                               |
+
+### Example TOML file
+
+```toml
+# config.toml
+
+# Mandatory fields
+
+# Note: Replace 'MY_PRIVATE_KEY' with the actual private key value
+signer_private_key = "MY_PRIVATE_KEY"
+stacks_node_rpc_url = "http://localhost:9776"
+bitcoin_node_rpc_url = "http://localhost:9777"
+revealer_rpc_url = "http://locahost:9778"
+
+# Optional fields
+network = "Signet"
+auto_approve_max_amount = 500000
+auto_deny_addresses_btc = [
+	"BTC_ADDRESS_1",
+	"BTC_ADDRESS_2"
+]
+auto_deny_addresses_stx = [
+	"STX_ADDRESS"
+]
+auto_deny_deadline_blocks = 120
+```
+
+## Running the binary
+
+After installing and creating a config file to run the binary
+
+```console
+stacks-signer-mini --config conf/signer.toml
+```
+
+## Monitor Transactions
+
+The signer binary operates a web server/client and it can be navigated to by default at http://localhost:3000/ (unless otherwise specified from config). Here you can see pending transactions and manually review and sign transactions that cannot be automatically signed on your behalf. Note that manual review is triggered based on the options you have set in your configuration file.


### PR DESCRIPTION


## Description

Updated User guide section in regards towards running a sBTC Signer
- Added new page "Nakamoto Signer Get Started"
 - this includes the latest planned configuration set up for running a signer, text describing how to run a custom signer if needed
 - Added a page describing the lack of signer in Developer release 
 
 

