### PR TITLE
Need jq installed locally for btc mining script to work

### DIFF
--- a/src/local-setup.md
+++ b/src/local-setup.md
@@ -17,6 +17,7 @@ Here are the basic steps we'll need to follow to get everything running.
 
 - Install [Docker](https://docs.docker.com/engine/install/).
 - Install [Clarinet](https://github.com/hirosystems/clarinet).
+- _Mac OS X_: Install [jq](https://formulae.brew.sh/formula/jq)
 
 ## Launch Devnet
 


### PR DESCRIPTION
## Description

The `mine_btc.sh` script doesn't work on OS X unless the JSON parser `jq` is available in the PATH. This change adds that as a requirement.

## Type of Change

Bug fix

