### PR TITLE
changed the loans map key to function properly

### DIFF
--- a/src/tutorial.md
+++ b/src/tutorial.md
@@ -639,7 +639,7 @@ First we're going to set up the data variables we need.
 ```clojure
 ;; Define the contract's data variables
 (define-map deposits { owner: principal } { amount: uint })
-(define-map loans principal { amount: uint, last-interaction-block: uint })
+(define-map loans {owner : principal} { amount: uint, last-interaction-block: uint })
 
 (define-data-var total-deposits uint u0)
 (define-data-var total-loans uint u0)


### PR DESCRIPTION
As a tester, I was trying to build the lagoon app in order to interact with the sBTC contract. I encountered an issue when attempting to deploy the contract, which led me to an error in the way the loans map was being initialized. 

solves issue #106 which I opened recently.
```

For details refer to issue #123


- API reference/documentation update

## Testing information

no testing required. 

## Checklist
- [na] Code is commented where needed
- [na] Unit test coverage for new or modified code paths
- [na] `npm run test` passes
- [na] Changelog is updated
- [na] Tag 1 of @person1 or @person2
