### PR TITLE
docs: fix minimum clarinet version

### DIFF
--- a/src/local-setup.md
+++ b/src/local-setup.md
@@ -16,7 +16,7 @@ Here are the basic steps we'll need to follow to get everything running.
 ### Requirements
 
 - Install [Docker](https://docs.docker.com/engine/install/).
-- Install [Clarinet](https://github.com/hirosystems/clarinet) (version 1.8.0 or higher).
+- Install [Clarinet](https://github.com/hirosystems/clarinet) (version 1.7.0 or higher).
 
 ## Launch Devnet
 


### PR DESCRIPTION
## Description

There was a lot of confusion because the docs says that sBTC requires clarinet v1.8.0 or higher, while v1.8.0 doesn't exist on homebrew (and never will).

Since v1.8.0 only brings changes that are needed for the hiro platform, it's doesn't change anything regarding sBTC, and version 1.7 which is the latest on homebrew will work just fine as well.

The next Clarinet version on homebrew will be 2.0 and should be released this week.

More context here: https://github.com/hirosystems/clarinet/issues/1065
