### PR TITLE
Change default branch references from master to main

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   deploy:

--- a/src/nakamoto-signer-developer-guide.md
+++ b/src/nakamoto-signer-developer-guide.md
@@ -39,10 +39,10 @@ cd stacks-blockchain/stacks-signer
 3. Checkout the appropriate release branch you wish to use if you are not using the default main branch
 
 ```console
-git checkout master
+git checkout main
 ```
 
-4. Compile the signer binary:  
+4. Compile the signer binary:
    Note the binary path defaults to `target/release/stacks-signer`.
 
 ```console

--- a/src/sbtc-releases/sbtc-dev.md
+++ b/src/sbtc-releases/sbtc-dev.md
@@ -26,7 +26,7 @@ graph TD;
 
 ## sBTC Developer release reference implementation plan
 
-The reference implementation of the sBTC developer release, codenamed Alpha Romeo, is currently under implementation in [this repository](https://github.com/stacks-network/sbtc/tree/master/romeo).
+The reference implementation of the sBTC developer release, codenamed Alpha Romeo, is currently under implementation in [this repository](https://github.com/stacks-network/sbtc/tree/main/romeo).
 Every piece of functionality that is being worked on is formulated as [issues](https://github.com/stacks-network/sbtc/issues) with the [sBTC DR] prefix and `alpha-romeo` label.
 
 For anyone interested in tracking the high-level progress of the Alpha Romeo work, these key issues should provide a good view in how things are progressing.

--- a/src/sbtc-roadmap.md
+++ b/src/sbtc-roadmap.md
@@ -40,7 +40,7 @@ gantt
     sBTC Releases              : doc3, after doc1, 2w
     sBTC Developer guides      : doc4, after doc2, 4w
     sBTC Nakamoto              : doc5, 2023-12-01, 8w
-  
+
 ```
 
 Each effort in the roadmap represents a key aspect of our development process. The following sections provide more detail about what we aim to achieve with each effort.


### PR DESCRIPTION
## Description

We have changed default branch to main, this commit changes the references to the main branch.

**NOTE:** A number of the links I've updated are actually relating to the default branch of the `sbtc` repository - those were actually wrong so I've updated those too.

Fixes: #86 

## Type of Change

Other

## Does this introduce a breaking change?

Nope

## Are documentation updates required?

Yes - done.

## Testing information

No testing

## Checklist
- [x] Code is commented where needed
- [x] Unit test coverage for new or modified code paths
- [ ] `npm run test` passes
- [x] Changelog is updated
- [ ] Tag 1 of @person1 or @person2
